### PR TITLE
Update dnf installation to be compatible with microdnf

### DIFF
--- a/packages/scripts/install.sh
+++ b/packages/scripts/install.sh
@@ -211,9 +211,7 @@ _install_rpm_key() {
   rpm --verbose --import https://build.opensuse.org/projects/${OBS_PROJECT}/signing_keys/download?kind=gpg
 }
 
-_install_yum() {
-  _install_rpm_key
-
+_add_yum_repo() {
   cat > /etc/yum.repos.d/crystal.repo <<EOF
 [crystal]
 name=Crystal (${DISTRO_REPO})
@@ -223,6 +221,11 @@ gpgcheck=1
 gpgkey=https://download.opensuse.org/repositories/${OBS_PROJECT//:/:\/}/${DISTRO_REPO}/repodata/repomd.xml.key
 enabled=1
 EOF
+}
+
+_install_yum() {
+  _install_rpm_key
+  _add_yum_repo
 
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     yum install -y crystal
@@ -232,8 +235,8 @@ EOF
 }
 
 _install_dnf() {
-  dnf install -y 'dnf-command(config-manager)'
-  dnf config-manager --add-repo https://download.opensuse.org/repositories/${OBS_PROJECT}/$DISTRO_REPO/${OBS_PROJECT}.repo
+  _install_rpm_key
+  _add_yum_repo
 
   if [[ "$CRYSTAL_VERSION" == "latest" ]]; then
     dnf install -y crystal


### PR DESCRIPTION
Addresses #322.

Currently, the script uses dnf config-manager to add crystal repo on dnf based systems. The problem with this approach is that config-manager is a plugin for the python implementation of dnf [that will eventually be replaced by the new microdnf implementation](https://fedoraproject.org/wiki/Changes/MajorUpgradeOfMicrodnf#Detailed_Description). Some systems targeted at leaner installations only include microdnf, which is not compatible with the full dnf plugins, making them incompatible with the current strategy.

This PR updates repository installation to manually create [a repo file under /etc/yum.repos.d](https://dnf.readthedocs.io/en/latest/conf_ref.html#description) on dnf systems, just like what is currently done for yum based systems. This change not only enables the script to work with microdnf, but also reduces the number of dependencies installed on full dnf as a side-effect.

Tested on Fedora 37, 40 and rawhide containers for regressions.